### PR TITLE
Add variables to set artefacts to produce.

### DIFF
--- a/cmake/sca/eclair/sca.cmake
+++ b/cmake/sca/eclair/sca.cmake
@@ -76,6 +76,7 @@ add_custom_command(
   ${ECLAIR_REPORT} \
   -eval_file=${ECLAIR_ECL_DIR}/reports.ecl \
   | tee ${ECLAIR_OUTPUT_DIR}/report.log"
+  COMMAND ${ECLAIR_REPORT} -db=${ECLAIR_PROJECT_ECD} -overall_txt=/dev/stdin
   VERBATIM
   USES_TERMINAL
   COMMAND_EXPAND_LISTS


### PR DESCRIPTION
The following variables can be set either to false or true:

ECLAIR_metrics_tab      metrics in spreadsheet format
ECLAIR_reports_tab      findings in spreadsheet format
ECLAIR_summary_txt      summary report in plain textual format
ECLAIR_summary_doc      summary report in DOC format
ECLAIR_summary_odt      summary report in ODT format
ECLAIR_full_txt_areas   enable/disable detailed reports in txt format
ECLAIR_full_txt         rich/detailed report in plain textual format
ECLAIR_full_doc_areas   enable/disable detailed reports in ODT/DOC format
ECLAIR_full_doc         rich/detailed report in DOC format
ECLAIR_full_odt         rich/detailed report in ODT format